### PR TITLE
Fixed issue with IP ban-list

### DIFF
--- a/docker/monero/entrypoint.sh
+++ b/docker/monero/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if curl --fail --connect-timeout 10 --verbose https://gui.xmr.pm/files/block.txt --output /tmp/block.txt; then
-  mv /tmp/block.txt /var/monero/block.txt
+if ! curl --fail --connect-timeout 10 --verbose https://gui.xmr.pm/files/block.txt --output /var/monero/block.txt; then
+  touch /var/monero/block.txt
 fi
 
 exec "/monerod" \


### PR DESCRIPTION
This pull request fixes an issue where the `monero` container won't start unless `block.txt` is manually created.

I noticed that the entrypoint script downloads block.txt to /tmp, but /tmp is mounted read-only in the container for some reason:

```bash
Warning: Failed to create the file /tmp/block.txt: Read-only file system
* Failure writing output to destination
```

This causes monerod to fail:

```
Exception in main! Can't find ban list file /var/monero/block.txt - No such file or directory
```

I changed the script to download the file directly to /var/monero without saving a temporary copy first. If the download fails, block.txt will be created using `touch` to ensure that monerod always starts up.