### PR TITLE
Monero v0.18.1 and Alpine 3.16.2 Updates

### DIFF
--- a/docker/monero/Dockerfile
+++ b/docker/monero/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     gperf \
     unzip \
     linux-headers \
+    expat-dev \
     libexecinfo-dev
 
 WORKDIR /usr/local
@@ -110,6 +111,18 @@ RUN set -ex \
     && test `git rev-parse HEAD` = ${PROTOBUF_HASH} || exit 1 \
     && git submodule update --init --recursive \
     && ./autogen.sh \
+    && ./configure --enable-static --disable-shared \
+    && make -j$(nproc) \
+    && make install
+
+# Unbound
+ARG UNBOUND_VERSION=release-1.16.2
+ARG UNBOUND_HASH=cbed768b8ff9bfcf11089a5f1699b7e5707f1ea5
+RUN set -ex \
+    && git clone https://github.com/NLnetLabs/unbound.git -b ${UNBOUND_VERSION} \
+    && cd unbound \
+    && test `git rev-parse HEAD` = ${UNBOUND_HASH} || exit 1 \
+    && git submodule update --init --recursive \
     && ./configure --enable-static --disable-shared \
     && make -j$(nproc) \
     && make install

--- a/docker/monero/Dockerfile
+++ b/docker/monero/Dockerfile
@@ -1,6 +1,6 @@
 # Partially copied from https://github.com/monero-project/monero/blob/8c3c7b81097b8e260f050b223e7fa3958c14ae66/Dockerfile
 
-FROM alpine:3.16 AS builder
+FROM alpine:3.16.2 AS builder
 
 RUN apk add --no-cache \
     git \
@@ -142,7 +142,7 @@ RUN mkdir build && cd build && \
     cmake --build . --target daemon -- -j$(nproc)
 
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 RUN apk add --no-cache curl ca-certificates bash
 

--- a/docker/monero/Dockerfile
+++ b/docker/monero/Dockerfile
@@ -129,7 +129,7 @@ RUN set -ex \
 
 WORKDIR /src
 
-ARG ref=origin/master
+ARG ref=727bc5b6878170332bf2d838f2c60d1c8dc685c8
 
 RUN git clone --recursive https://github.com/monero-project/monero /src && \
     git reset --hard ${ref} && \

--- a/docker/p2pool/Dockerfile
+++ b/docker/p2pool/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS builder
+FROM alpine:3.16.2 AS builder
 
 RUN apk add --no-cache git gcc g++ cmake make libtool autoconf automake
 
@@ -31,7 +31,7 @@ RUN mkdir build && cd build && \
     cmake .. -DSTATIC_BINARY=ON && \
     make -j$(nproc)
 
-FROM alpine:3.16
+FROM alpine:3.16.2
 
 RUN apk add --no-cache curl jq bash
 


### PR DESCRIPTION
* Build unbound for Monero v0.18.x+
* Alpine -> 3.16.2 for both images